### PR TITLE
Fix indentation of curly bracket

### DIFF
--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -760,7 +760,7 @@ autofill-mode."
     (purescript-indentation-implicit-layout-list parser)))
 
 (defun purescript-indentation-expression-token (token)
-  (member token '("if" "let" "do" "case" "\\" "(" "[" "::"
+  (member token '("if" "let" "do" "case" "\\" "(" "[" "{" "::"
                   value operator no-following-token)))
 
 (defun purescript-indentation-expression ()


### PR DESCRIPTION
This PR fixes an indentation problem of an open curly bracket of a record.

```purescript
  [ R.div
    { className: "flex" -- <- This should be possibly indented as a normal expression
    , ...
    }
  ]
```