### PR TITLE
Fix `cl-multiple-value-bind` and hence `purescript-pursuit`

### DIFF
--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -212,7 +212,7 @@ May return a qualified name."
         (skip-chars-backward " \t"))
 
     (let ((case-fold-search nil))
-      (multiple-value-bind (start end)
+      (cl-multiple-value-bind (start end)
           (if (looking-at "\\s_")
               (list (progn (skip-syntax-backward "_") (point))
                     (progn (skip-syntax-forward "_") (point)))


### PR DESCRIPTION
Previously `purescript-pursuit` failed with `Symbol’s value as variable is void: end` and byte compiling warned of free variables `start` and `end`.