### PR TITLE
Fix indentation of row type

### DIFF
--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -507,7 +507,7 @@ autofill-mode."
     ("["     . (lambda () (purescript-indentation-list #'purescript-indentation-type
                                                     "]" "," nil)))
     ("{"     . (lambda () (purescript-indentation-list #'purescript-indentation-type
-                                                    "}" "," nil)))))
+                                                    "}" "," "|")))))
 
 (defconst purescript-indentation-expression-list
   '(("data" . purescript-indentation-data)


### PR DESCRIPTION
This fixes "Parse error" of indentation in the following case:

```purescript
let x = { foo: 3, bar: 4 } :: { | a }
```