### PR TITLE
purescript-indentation.el: improve compiler visibility into local variables

### DIFF
--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -1,4 +1,4 @@
-;;; purescript-indentation.el -- indentation module for PureScript Mode
+;;; purescript-indentation.el -- indentation module for PureScript Mode -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2009  Kristof Bastiaensen
 


### PR DESCRIPTION
Turning on lexical-binding fixes a bunch of warnings like:

    purescript-indentation.el:399:47: Warning: ‘pi’ is an obsolete variable (as of 23.3); use ‘float-pi’ instead.

these warnings are caused by Emacs not being able to determine that `pi` is actually a local variable. By making use of lexical binding we make Emacs to be able to see through that.