### PR TITLE
Fixing all byte-compilation errors

### DIFF
--- a/purescript-align-imports.el
+++ b/purescript-align-imports.el
@@ -1,4 +1,4 @@
-;;; purescript-align-imports.el --- Align the import lines in a PureScript file
+;;; purescript-align-imports.el --- Align the import lines in a PureScript file -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010  Chris Done
 

--- a/purescript-collapse.el
+++ b/purescript-collapse.el
@@ -1,4 +1,4 @@
-;;; purescript-collapse.el --- Collapse expressions
+;;; purescript-collapse.el --- Collapse expressions -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2014 Chris Done. All rights reserved.
 

--- a/purescript-decl-scan.el
+++ b/purescript-decl-scan.el
@@ -1,4 +1,4 @@
-;;; purescript-decl-scan.el --- Declaration scanning module for PureScript Mode
+;;; purescript-decl-scan.el --- Declaration scanning module for PureScript Mode -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2004, 2005, 2007, 2009  Free Software Foundation, Inc.
 ;; Copyright (C) 1997-1998  Graeme E Moss

--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -1,4 +1,4 @@
-;;; purescript-font-lock.el --- Font locking module for PureScript Mode
+;;; purescript-font-lock.el --- Font locking module for PureScript Mode -*- lexical-binding: t -*-
 
 ;; Copyright 2003, 2004, 2005, 2006, 2007, 2008  Free Software Foundation, Inc.
 ;; Copyright 1997-1998  Graeme E Moss, and Tommy Thorn

--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -448,7 +448,7 @@ that should be commented under LaTeX-style literate scripts."
 (defun turn-on-purescript-font-lock ()
   "Turns on font locking in current buffer for PureScript 1.4 scripts.
 
-Changes the current buffer's `font-lock-defaults', and adds the
+Changes the current buffer\\='s `font-lock-defaults', and adds the
 following variables:
 
    `purescript-keyword-face'      for reserved keywords and syntax,
@@ -470,7 +470,7 @@ Use the variable `font-lock-maximum-decoration' to choose
 non-default levels of fontification.  For example, adding this to
 .emacs:
 
-  (setq font-lock-maximum-decoration '((purescript-mode . 2) (t . 0)))
+  (setq font-lock-maximum-decoration \\='((purescript-mode . 2) (t . 0)))
 
 uses level two fontification for `purescript-mode' and default level for
 all other modes.  See documentation on this variable for further
@@ -480,9 +480,9 @@ To alter an attribute of a face, add a hook.  For example, to change
 the foreground colour of comments to brown, add the following line to
 .emacs:
 
-  (add-hook 'purescript-font-lock-hook
+  (add-hook \\='purescript-font-lock-hook
       (lambda ()
-          (set-face-foreground 'purescript-comment-face \"brown\")))
+          (set-face-foreground \\='purescript-comment-face \"brown\")))
 
 Note that the colours available vary from system to system.  To see
 what colours are available on your system, call
@@ -490,7 +490,7 @@ what colours are available on your system, call
 
 To turn font locking on for all PureScript buffers, add this to .emacs:
 
-  (add-hook 'purescript-mode-hook 'turn-on-purescript-font-lock)
+  (add-hook \\='purescript-mode-hook \\='turn-on-purescript-font-lock)
 
 To turn font locking on for the current buffer, call
 `turn-on-purescript-font-lock'.  To turn font locking off in the current

--- a/purescript-indent.el
+++ b/purescript-indent.el
@@ -1,4 +1,4 @@
-;;; purescript-indent.el --- "semi-intelligent" indentation module for PureScript Mode
+;;; purescript-indent.el --- "semi-intelligent" indentation module for PureScript Mode -*- lexical-binding: t -*-
 
 ;; Copyright 2004, 2005, 2007, 2008, 2009  Free Software Foundation, Inc.
 ;; Copyright 1997-1998  Guy Lapalme

--- a/purescript-indent.el
+++ b/purescript-indent.el
@@ -432,7 +432,8 @@ Returns the location of the start of the comment, nil otherwise."
         (purescript-indent-skip-blanks-and-newlines-forward end))))
 
 (defun purescript-indent-next-symbol-safe (end)
-  "Puts point to the next following symbol, or to end if there are no more symbols in the sexp."
+  "Puts point to the next following symbol, or to end if there are no more
+symbols in the sexp."
   (condition-case errlist (purescript-indent-next-symbol end)
     (error (goto-char end))))
 

--- a/purescript-indent.el
+++ b/purescript-indent.el
@@ -1321,7 +1321,7 @@ of the regions to move."
 (defun purescript-indent-align-def (p-arg type)
   "Align guards or rpurs within the current definition before point.
 If P-ARG is t align all defs up to the mark.
-TYPE is either 'guard or 'rpurs."
+TYPE is either \\='guard or \\='rpurs."
   (save-excursion
     (let (start-block end-block
                       (maxcol (if (eq type 'rpurs) purescript-indent-rpurs-align-column 0))

--- a/purescript-indent.el
+++ b/purescript-indent.el
@@ -434,7 +434,7 @@ Returns the location of the start of the comment, nil otherwise."
 (defun purescript-indent-next-symbol-safe (end)
   "Puts point to the next following symbol, or to end if there are no more
 symbols in the sexp."
-  (condition-case errlist (purescript-indent-next-symbol end)
+  (condition-case nil (purescript-indent-next-symbol end)
     (error (goto-char end))))
 
 (defun purescript-indent-separate-valdef (start end)
@@ -1292,7 +1292,7 @@ We stay in the cycle as long as the TAB key is pressed."
         (if marker
             (goto-char (marker-position marker)))))))
 
-(defun purescript-indent-region (start end)
+(defun purescript-indent-region (_start _end)
   (error "Auto-reindentation of a region is not supported"))
 
 ;;; alignment functions
@@ -1430,9 +1430,9 @@ TYPE is either \\='guard or \\='rpurs."
             (if regstack
                 (purescript-indent-shift-columns maxcol regstack)))))))
 
-(defun purescript-indent-align-guards-and-rpurs (start end)
+(defun purescript-indent-align-guards-and-rpurs (_start _end)
   "Align the guards and rpurs of functions in the region, which must be active."
-  ;; The `start' and `end' args are dummys right now: they're just there so
+  ;; The `_start' and `_end' args are dummys right now: they're just there so
   ;; we can use the "r" interactive spec which properly signals an error.
   (interactive "*r")
   (purescript-indent-align-def t 'guard)

--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -1,4 +1,4 @@
-;;; purescript-indentation.el -- indentation module for PureScript Mode -*- lexical-binding: t -*-
+;;; purescript-indentation.el -- indentation module for PureScript Mode -*- lexical-binding: t -*- -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2009  Kristof Bastiaensen
 

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -87,7 +87,7 @@ When MESSAGE is non-nil, display a message with the version."
 ;;;###autoload
 (defun purescript-customize ()
   "Browse the purescript customize sub-tree.
-This calls 'customize-browse' with purescript as argument and makes
+This calls `customize-browse' with purescript as argument and makes
 sure all purescript customize definitions have been loaded."
   (interactive)
   ;; make sure all modules with (defcustom ...)s are loaded

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -1,4 +1,4 @@
-;;; purescript-mode.el --- A PureScript editing mode    -*- coding: utf-8 -*-
+;;; purescript-mode.el --- A PureScript editing mode    -*- coding: utf-8 lexical-binding: t -*-
 
 ;; Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008  Free Software Foundation, Inc
 ;; Copyright (C) 1992, 1997-1998  Simon Marlow, Graeme E Moss, and Tommy Thorn

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -445,7 +445,9 @@ is asked to show extra info for the items matching QUERY.."
   :safe 'integerp)
 
 (defun purescript-mode-suggest-indent-choice ()
-  "Ran when the user tries to indent in the buffer but no indentation mode has been selected.
+  "Ran when the user tries to indent in the buffer but no indentation mode
+has been selected.
+
 Brings up the documentation for purescript-mode-hook."
   (describe-variable 'purescript-mode-hook))
 

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -60,13 +60,13 @@ When MESSAGE is non-nil, display a message with the version."
   (interactive "P")
   (let* ((purescript-mode-dir (ignore-errors
                              (file-name-directory (or (locate-library "purescript-mode") ""))))
-         (_version (format "purescript-mode version %s (%s @ %s)"
+         (version (format "purescript-mode version %s (%s @ %s)"
                            purescript-version
                            purescript-git-version
                            purescript-mode-dir)))
     (if here
-        (insert _version)
-      (message "%s" _version))))
+        (insert version)
+      (message "%s" version))))
 
 ;;;###autoload
 (defun purescript-mode-view-news ()

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -413,7 +413,7 @@ see documentation for that variable for more details."
 
 ;;;###autoload(add-to-list 'auto-mode-alist '("\\.purs\\'" . purescript-mode))
 
-(defun purescript-pursuit (query &optional info)
+(defun purescript-pursuit (query &optional _info)
   "Do a Pursuit search for QUERY.
 When `purescript-pursuit-command' is non-nil, this command runs
 that.  Otherwise, it opens a Pursuit search result in the browser.

--- a/purescript-move-nested.el
+++ b/purescript-move-nested.el
@@ -1,4 +1,4 @@
-;;; purescript-move-nested.el --- Change the column of text nested below a line
+;;; purescript-move-nested.el --- Change the column of text nested below a line -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010  Chris Done
 

--- a/purescript-move-nested.el
+++ b/purescript-move-nested.el
@@ -34,7 +34,8 @@
 
 ;;;###autoload
 (defun purescript-move-nested (cols)
-  "Shift the nested off-side-rule block adjacent to point by COLS columns to the right.
+  "Shift the nested off-side-rule block adjacent to point by COLS columns
+to the right.
 
 In Transient Mark mode, if the mark is active, operate on the contents
 of the region instead.

--- a/purescript-navigate-imports.el
+++ b/purescript-navigate-imports.el
@@ -1,4 +1,4 @@
-;;; purescript-navigate-imports.el --- A function for cycling through PureScript import lists
+;;; purescript-navigate-imports.el --- A function for cycling through PureScript import lists -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010  Chris Done
 

--- a/purescript-navigate-imports.el
+++ b/purescript-navigate-imports.el
@@ -98,10 +98,9 @@
                     (purescript-navigate-imports-after-imports-p) ;; This one just speeds it up.
                     (purescript-navigate-imports-line)))
       (forward-line))
-    (let ((point (point)))
-      (if (purescript-navigate-imports-line)
-          (point)
-        nil))))
+    (if (purescript-navigate-imports-line)
+        (point)
+      nil)))
 
 (defun purescript-navigate-imports-line ()
   "Try to match the current line as a regexp."

--- a/purescript-presentation-mode.el
+++ b/purescript-presentation-mode.el
@@ -1,4 +1,4 @@
-;;; purescript-presentation-mode.el --- Presenting PureScript things
+;;; purescript-presentation-mode.el --- Presenting PureScript things -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013  Chris Done
 

--- a/purescript-show.el
+++ b/purescript-show.el
@@ -1,4 +1,4 @@
-;;; purescript-show.el --- A pretty printer for PureScript Show values
+;;; purescript-show.el --- A pretty printer for PureScript Show values -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011  Chris Done
 

--- a/purescript-simple-indent.el
+++ b/purescript-simple-indent.el
@@ -1,4 +1,4 @@
-;;; purescript-simple-indent.el --- Simple indentation module for PureScript Mode
+;;; purescript-simple-indent.el --- Simple indentation module for PureScript Mode -*- lexical-binding: t -*-
 
 ;; Copyright (C) 1998  Heribert Schuetz, Graeme E Moss
 

--- a/purescript-simple-indent.el
+++ b/purescript-simple-indent.el
@@ -143,19 +143,18 @@ column, `tab-to-tab-stop' is done instead."
 (defun purescript-simple-indent-newline-same-col ()
   "Make a newline and go to the same column as the current line."
   (interactive)
-  (let ((point (point)))
-    (let ((start-end
-           (save-excursion
-             (let* ((start (line-beginning-position))
-                    (end (progn (goto-char start)
-                                (search-forward-regexp
-                                 "[^ ]" (line-end-position) t 1))))
-               (when end (cons start (1- end)))))))
-      (if start-end
-          (progn (newline)
-                 (insert (buffer-substring-no-properties
-                          (car start-end) (cdr start-end))))
-        (newline)))))
+  (let ((start-end
+         (save-excursion
+           (let* ((start (line-beginning-position))
+                  (end (progn (goto-char start)
+                              (search-forward-regexp
+                               "[^ ]" (line-end-position) t 1))))
+             (when end (cons start (1- end)))))))
+    (if start-end
+        (progn (newline)
+               (insert (buffer-substring-no-properties
+                        (car start-end) (cdr start-end))))
+      (newline))))
 
 (defun purescript-simple-indent-newline-indent ()
   "Make a newline on the current column and indent on step."

--- a/purescript-sort-imports.el
+++ b/purescript-sort-imports.el
@@ -38,12 +38,12 @@
 
 ;;;###autoload
 (defun purescript-sort-imports ()
-  (interactive)
   "Sort the import list at point. It sorts the current group
 i.e. an import list separated by blank lines on either side.
 
 If the region is active, it will restrict the imports to sort
 within that region."
+  (interactive)
   (when (purescript-sort-imports-at-import)
     (let* ((points (purescript-sort-imports-decl-points))
            (current-string (buffer-substring-no-properties (car points)

--- a/purescript-sort-imports.el
+++ b/purescript-sort-imports.el
@@ -1,4 +1,4 @@
-;;; purescript-sort-imports.el --- Sort the list of PureScript imports at the point alphabetically
+;;; purescript-sort-imports.el --- Sort the list of PureScript imports at the point alphabetically -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010  Chris Done
 

--- a/purescript-str.el
+++ b/purescript-str.el
@@ -1,4 +1,4 @@
-;;; purescript-str.el --- PureScript related string utilities
+;;; purescript-str.el --- PureScript related string utilities -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013  Herbert Valerio Riedel
 

--- a/purescript-string.el
+++ b/purescript-string.el
@@ -1,3 +1,4 @@
+;;; purescript-string.el --- string manipulation utilties -*- lexical-binding: t -*-
 ;;;###autoload
 (defun purescript-trim (string)
   (replace-regexp-in-string

--- a/purescript-unicode-input-method.el
+++ b/purescript-unicode-input-method.el
@@ -1,4 +1,4 @@
-;;; purescript-unicode-input-method.el --- PureScript Unicode helper functions  -*- coding: utf-8 -*-
+;;; purescript-unicode-input-method.el --- PureScript Unicode helper functions  -*- coding: utf-8 lexical-binding: t -*-
 
 ;; Copyright (C) 2010-2011  Roel van Dijk
 

--- a/purescript-utils.el
+++ b/purescript-utils.el
@@ -1,4 +1,4 @@
-;;; purescript-utils.el --- General utility functions used by purescript-mode modules
+;;; purescript-utils.el --- General utility functions used by purescript-mode modules -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013  Herbert Valerio Riedel
 

--- a/purescript-yas.el
+++ b/purescript-yas.el
@@ -1,4 +1,4 @@
-;;; purescript-yas.el --- Customization support for Luke Hoersten's yasnippets
+;;; purescript-yas.el --- Customization support for Luke Hoersten's yasnippets -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013  John Wiegley, Luke Hoersten
 

--- a/tests/haskell-sort-imports-tests.el
+++ b/tests/haskell-sort-imports-tests.el
@@ -1,4 +1,4 @@
-;;; purescript-sort-imports-tests.el --- Unit tests for purescript-sort-imports
+;;; purescript-sort-imports-tests.el --- Unit tests for purescript-sort-imports -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2014 Chris Done. All rights reserved.
 


### PR DESCRIPTION
Per discussion [here](https://github.com/purescript-emacs/purescript-mode/pull/19), I decided to fix byte-compilation errors that are currently present in the package. As a bonus, this enables lexical binding everywhere, so Emacs will have better introspection into the package, thus enabling more optimizations.

Each error is being fixed in its own commit.

On my latest Emacs from upstream this branch currently passes with no errors, Idk if there will be something on older Emacses being being tested, will see I guess.