### PR TITLE
Implement ability to switch from .purs to .js FFI file

### DIFF
--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -37,6 +37,7 @@
 (require 'purescript-string)
 (require 'purescript-font-lock)
 (require 'cl-lib)
+(cl-eval-when 'compile (require 'find-file))
 
 ;; All functions/variables start with `(literate-)purescript-'.
 
@@ -341,7 +342,9 @@ see documentation for that variable for more details."
   (set (make-local-variable 'dabbrev-case-replace) nil)
   (set (make-local-variable 'dabbrev-abbrev-char-regexp) "\\sw\\|[.]")
   (setq-local beginning-of-defun-function 'purescript-beginning-of-defun)
-  (setq prettify-symbols-alist purescript-font-lock-prettify-symbols-alist)
+  (setq prettify-symbols-alist purescript-font-lock-prettify-symbols-alist
+        ;; make (ff-find-other-file) find .js FFI file, given .purs
+        ff-other-file-alist '((".purs\\'" (".js"))))
   (when (bound-and-true-p purescript-font-lock-symbols)
     (warn "`purescript-font-lock-symbols' is obsolete: please enable `prettify-symbols-mode' locally or globally instead."))
   )


### PR DESCRIPTION
Emacs provides a `(ff-find-other-file nil t)` function to switch between header and implementations. The closest PureScript has to such idea is the FFI, where given `Foo.purs` there has to be similarly named `Foo.js`, and unsurprisingly I keep pressing a keybind trying to switch between them.

So add the mapping from `.purs` to `.js`.

Worth noting that this doesn't provide the reverse mapping `.js → .purs` because js is a different major mode and we can't be making assumptions on whether it's related to PureScript… Usually. We probably could reassign in case the js file was open by the `ff-find-other-file`, but let's keep it simple for now.