### PR TITLE
Avoid redefining conflict marker faces from smerge-mode

### DIFF
--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -205,9 +205,6 @@ Returns keywords suitable for `font-lock-keywords'."
     (setq keywords
           `(;; NOTICE the ordering below is significant
             ;;
-            ("^<<<<<<< .*$" 0 'font-lock-warning-face t)
-            ("^=======" 0 'font-lock-warning-face t)
-            ("^>>>>>>> .*$" 0 'font-lock-warning-face t)
             ("^#.*$" 0 'font-lock-preprocessor-face t)
 
             (,reservedid 1 (symbol-value 'purescript-keyword-face))


### PR DESCRIPTION
CC: @chrisdone who authored adding the faces in a469367

Whenever conflicts appear in Emacs buffer, they get handled by smerge-mode. The mode isn't enabled by default, but it gets turned on upon conflict markers entering the buffer.

There's no point in redefining what's already handled by Emacs.