### PR TITLE
Don't highlight top-level-only keywords at different levels

### DIFF
--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -178,7 +178,7 @@ Returns keywords suitable for `font-lock-keywords'."
          (toplevel-keywords
           (rx line-start (zero-or-more whitespace)
               (group (or "type" "module" "import" "data" "class" "newtype"
-                         "instance")
+                         "instance" "derive")
                      word-end)))
          ;; Reserved identifiers
          (reservedid
@@ -186,7 +186,7 @@ Returns keywords suitable for `font-lock-keywords'."
           ;; spec syntax, but they are not reserved.
           ;; `_' can go in here since it has temporary word syntax.
           (regexp-opt
-           '("ado" "case" "default" "deriving" "do" "else" "if" "in" "infix"
+           '("ado" "case" "default" "do" "else" "if" "in" "infix"
              "infixl" "infixr" "let" "of" "then" "where" "_") 'words))
 
          ;; Top-level declarations

--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -172,16 +172,22 @@ Returns keywords suitable for `font-lock-keywords'."
                   ;;            "@" "~" "=>") t)
                   "\\(->\\|\\.\\.\\|::\\|∷\\|<-\\|=>\\|[=@\\|~]\\)"
                   "\\S_"))
+         ;; These are only keywords when appear at top-level, optionally with
+         ;; indentation. They are not reserved and in other levels would represent
+         ;; record fields or other identifiers.
+         (toplevel-keywords
+          (rx line-start (zero-or-more whitespace)
+              (group (or "type" "module" "import" "data" "class" "newtype"
+                         "instance")
+                     word-end)))
          ;; Reserved identifiers
          (reservedid
           ;; `as', `hiding', and `qualified' are part of the import
           ;; spec syntax, but they are not reserved.
           ;; `_' can go in here since it has temporary word syntax.
           (regexp-opt
-           '("ado" "case" "class" "data" "default" "deriving"
-             "do" "else" "if" "import" "in" "infix" "infixl"
-             "infixr" "instance" "let" "module" "newtype" "of"
-             "then" "type" "where" "_") 'words))
+           '("ado" "case" "default" "deriving" "do" "else" "if" "in" "infix"
+             "infixl" "infixr" "let" "of" "then" "where" "_") 'words))
 
          ;; Top-level declarations
          (topdecl-var
@@ -210,6 +216,7 @@ Returns keywords suitable for `font-lock-keywords'."
             ("^>>>>>>> .*$" 0 'font-lock-warning-face t)
             ("^#.*$" 0 'font-lock-preprocessor-face t)
 
+            (,toplevel-keywords 1 (symbol-value 'purescript-keyword-face))
             (,reservedid 1 (symbol-value 'purescript-keyword-face))
             (,reservedsym 1 (symbol-value 'purescript-operator-face))
             ;; Special case for `as', `hiding', `safe' and `qualified', which are


### PR DESCRIPTION
The keywords being modified here only represented keywords when they are at the beginning of a line with optional whitespace.

At different levels these would represent valid record fields or other identifiers.

This was tested by adding the following code to a PureScript file:

    type Foo = { type :: Int
               , module :: Int
               , import :: Int
               , data :: Int
               , class :: Int
               , newtype :: Int
               , instance :: Int
               }

…and checking that compilation succeeds.
