### PR TITLE
Simplify `purescript-ds-create-imenu-index` with hashtable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ELFILES = \
 	purescript-string.el \
 	purescript-unicode-input-method.el \
 	purescript-utils.el \
+	purescript-decl-scan.el \
 	purescript-yas.el
 
 ELCFILES = $(ELFILES:.el=.elc)


### PR DESCRIPTION
The function has implemented a poor man's hash table by manually enlisting keys and then jumping through the hoops by fetching them from one place, converting values to symbols to values… In particular, it was using `symbol-value` to map a symbol to its value, however the symbol was a local variable, and `symbol-value` doesn't work with them under lexical-binding, which the file was converted to since commit 9a9f550.

So fix the regression and simplify the code at the same time.

Fixes: https://github.com/purescript-emacs/purescript-mode/issues/25