### PR TITLE
Remove `default` keyword

### DIFF
--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -186,7 +186,7 @@ Returns keywords suitable for `font-lock-keywords'."
           ;; spec syntax, but they are not reserved.
           ;; `_' can go in here since it has temporary word syntax.
           (regexp-opt
-           '("ado" "case" "default" "do" "else" "if" "in" "infix"
+           '("ado" "case" "do" "else" "if" "in" "infix"
              "infixl" "infixr" "let" "of" "then" "where" "_") 'words))
 
          ;; Top-level declarations


### PR DESCRIPTION
I just stumbled upon a code in PS `routing-duplex`, where `default` is a function name and it's getting highlighted. That made me dig to see where such keyword could be used to reduce the possibility of such false-positives.

Now, I personally don't remember `default` being ever used as a keyword in PS. So I asked an AI but it doesn't know either. Then as a last measure I looked at syntax highlight in VS Code editor, and they don't highlight `default` either.

So remove `default` from the list of keywords.