### PR TITLE
Remove remains of `deriving` and decypher large regexp

### DIFF
--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -649,7 +649,7 @@ indent the current line. This has to be fixed elsewhere."
      (purescript-indentation-type)
      (cond ((string= current-token "=")
             (purescript-indentation-with-starter
-             (lambda () (purescript-indentation-separated #'purescript-indentation-type "|" "deriving"))
+             (lambda () (purescript-indentation-separated #'purescript-indentation-type "|" nil))
              nil))
            ((string= current-token "where")
             (purescript-indentation-with-starter
@@ -998,7 +998,7 @@ indent the current line. This has to be fixed elsewhere."
 
 (defun purescript-indentation-peek-token ()
   "Return token starting at point."
-  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|ado\\|mdo\\|rec\\|\\(?:[[:word:]]+\\.\\)*do\\|proc\\|case\\|of\\|where\\|module\\|deriving\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
+  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|ado\\|mdo\\|rec\\|\\(?:[[:word:]]+\\.\\)*do\\|proc\\|case\\|of\\|where\\|module\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
          (match-string-no-properties 1))
         ((looking-at "[][(){}[,;]")
          (match-string-no-properties 0))

--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -998,7 +998,13 @@ indent the current line. This has to be fixed elsewhere."
 
 (defun purescript-indentation-peek-token ()
   "Return token starting at point."
-  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|ado\\|mdo\\|rec\\|\\(?:[[:word:]]+\\.\\)*do\\|proc\\|case\\|of\\|where\\|module\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
+  (cond ((looking-at
+          (rx (group
+               (or "if" "then" "else" "let" "in" "ado" "mdo" "rec"
+                   (seq (0+ (seq (1+ word) ".")) "do")
+                   "proc" "case" "of" "where" "module" "data" "type" "newtype"
+                   "class" "instance"))
+              (group (or (not (any alnum "'_")) eol))))
          (match-string-no-properties 1))
         ((looking-at "[][(){}[,;]")
          (match-string-no-properties 0))


### PR DESCRIPTION
First commit removes the remains of `deriving` keyword. `deriving` isn't a thing in PureScript. Also, [related discussion on PureScript Discourse](https://discourse.purescript.org/t/solved-is-deriving-keyword-a-thing-in-purescript/4787).

Second commit is just a stylistic change: the large regexp in `purescript-indentation-peek-token` was converted to `rx` macro. It bears no functional change and the regexp generated by `rx` is exactly the same *(barring that `'_` part was to the right of `[:alnum:]` and now it's to the left)*. Hopefully, the resulting code is easier to read and maintain.