### PR TITLE
Use font-lock symbols directly instead of fetching from variables

### DIFF
--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -371,7 +371,7 @@ that should be commented under LaTeX-style literate scripts."
 (defun purescript-syntactic-face-function (state)
   "`font-lock-syntactic-face-function' for PureScript."
   (cond
-   ((nth 3 state) font-lock-string-face) ; as normal
+   ((nth 3 state) 'font-lock-string-face) ; as normal
    ;; Else comment.  If it's from syntax table, use default face.
    ((or (eq 'syntax-table (nth 7 state))
         (and (eq purescript-literate 'bird)
@@ -408,8 +408,8 @@ that should be commented under LaTeX-style literate scripts."
                         (setq doc (match-beginning 1)))
                       doc)))))
     (set (make-local-variable 'purescript-font-lock-seen-docstring) t)
-    font-lock-doc-face)
-   (t font-lock-comment-face)))
+    'font-lock-doc-face)
+   (t 'font-lock-comment-face)))
 
 (defconst purescript-font-lock-keywords
   (purescript-font-lock-keywords-create nil)


### PR DESCRIPTION
The variables are obsolete in Emacs 31.1+ because they introduce confusion (see https://debbugs.gnu.org/cgi/bugreport.cgi?bug=71469 for details).

Fixes:

    purescript-font-lock.el:374:19: Error: ‘font-lock-string-face’ is an obsolete variable (as of 31.1); use the quoted symbol instead: 'font-lock-string-face
    purescript-font-lock.el:411:5: Error: ‘font-lock-doc-face’ is an obsolete variable (as of 31.1); use the quoted symbol instead: 'font-lock-doc-face
    purescript-font-lock.el:412:7: Error: ‘font-lock-comment-face’ is an obsolete variable (as of 31.1); use the quoted symbol instead: 'font-lock-comment-face