### PR TITLE
Improve algorithm for imports sorting and remove an autoload

### DIFF
--- a/purescript-sort-imports.el
+++ b/purescript-sort-imports.el
@@ -32,8 +32,7 @@
 
 (defvar purescript-sort-imports-regexp
   (concat "^import[ ]+"
-          "\\(qualified \\)?"
-          "[ ]*\\(\"[^\"]*\" \\)?"
+          "\\(\"[^\"]*\" \\)?"
           "[ ]*\\([A-Za-z0-9_.']*.*\\)"))
 
 ;;;###autoload
@@ -68,9 +67,8 @@ within that region."
 
 (defun purescript-sort-imports-normalize (i)
   "Normalize an import, if possible, so that it can be sorted."
-  (if (string-match purescript-sort-imports-regexp
-                    i)
-      (match-string 3 i)
+  (if (string-match purescript-sort-imports-regexp i)
+      (match-string 2 i)
     i))
 
 (defun purescript-sort-imports-collect-imports ()

--- a/purescript-sort-imports.el
+++ b/purescript-sort-imports.el
@@ -35,7 +35,6 @@
           "\\(\"[^\"]*\" \\)?"
           "[ ]*\\([A-Za-z0-9_.']*.*\\)"))
 
-;;;###autoload
 (defun purescript-sort-imports ()
   "Sort the import list at point. It sorts the current group
 i.e. an import list separated by blank lines on either side.

--- a/tests/purescript-sort-imports-tests.el
+++ b/tests/purescript-sort-imports-tests.el
@@ -21,88 +21,88 @@
 (require 'purescript-sort-imports)
 
 (ert-deftest empty-buffer ()
-  (should (with-temp-buffer
-            (purescript-sort-imports)
-            t)))
+  (with-temp-buffer
+    (purescript-sort-imports)
+    t))
 
 (ert-deftest single-line ()
-  (should (with-temp-buffer
-            (insert "import A\n")
-            (goto-char (point-min))
-            (purescript-sort-imports)
-            (string= (buffer-string)
+  (with-temp-buffer
+    (insert "import A\n")
+    (goto-char (point-min))
+    (purescript-sort-imports)
+    (should (string= (buffer-string)
                      "import A\n"))))
 
 (ert-deftest two-idem ()
-  (should (with-temp-buffer
-            (insert "import A
+  (with-temp-buffer
+    (insert "import A
 import B
 ")
-            (goto-char (point-min))
-            (purescript-sort-imports)
-            (string= (buffer-string)
+    (goto-char (point-min))
+    (purescript-sort-imports)
+    (should (string= (buffer-string)
                      "import A
 import B
 ")))
-  (should (with-temp-buffer
-            (insert "import A (A, B, C)
+  (with-temp-buffer
+    (insert "import A (A, B, C)
 import B
 ")
-            (goto-char (point-min))
-            (purescript-sort-imports)
-            (string= (buffer-string)
+    (goto-char (point-min))
+    (purescript-sort-imports)
+    (should (string= (buffer-string)
                      "import A (A, B, C)
 import B
 ")))
-  (should (with-temp-buffer
-            (insert "import A (mtl)
+  (with-temp-buffer
+    (insert "import A (mtl)
 import B
 ")
-            (goto-char (point-min))
-            (purescript-sort-imports)
-            (string= (buffer-string)
+    (goto-char (point-min))
+    (purescript-sort-imports)
+    (should (string= (buffer-string)
                      "import A (mtl)
 import B
 "))))
 
 (ert-deftest two-rev ()
-  (should (with-temp-buffer
-            (insert "import B
+  (with-temp-buffer
+    (insert "import B
 import A
 ")
-            (goto-char (point-min))
-            (purescript-sort-imports)
-            (string= (buffer-string)
+    (goto-char (point-min))
+    (purescript-sort-imports)
+    (should (string= (buffer-string)
                      "import A
 import B
 "))))
 
 (ert-deftest file-structure ()
-  (should (with-temp-buffer
-            (insert "module A where
+  (with-temp-buffer
+    (insert "module A where
 import B
 import A
 ")
-            ;; test at line 2
-            (goto-char (point-min))
-            (forward-line 1)
-            (purescript-sort-imports)
-            (string= (buffer-string)
+    ;; test at line 2
+    (goto-char (point-min))
+    (forward-line 1)
+    (purescript-sort-imports)
+    (should (string= (buffer-string)
                      "module A where
 import A
 import B
 ")))
-  (should (with-temp-buffer
-            (insert "module C where
+  (with-temp-buffer
+    (insert "module C where
 
 import B
 import A
 ")
-            ;; test at line 3
-            (goto-char (point-min))
-            (forward-line 2)
-            (purescript-sort-imports)
-            (string= (buffer-string)
+    ;; test at line 3
+    (goto-char (point-min))
+    (forward-line 2)
+    (purescript-sort-imports)
+    (should (string= (buffer-string)
                      "module C where
 
 import A
@@ -110,8 +110,8 @@ import B
 "))))
 
 (ert-deftest bos-270 ()
-  (should (with-temp-buffer
-            (insert "import Data.Aeson.Encode (encode)
+  (with-temp-buffer
+    (insert "import Data.Aeson.Encode (encode)
 import Data.Aeson.Types
 import Data.Aeson.Parser.Internal (decodeWith, decodeStrictWith,
                                    eitherDecodeWith, eitherDecodeStrictWith,
@@ -119,9 +119,9 @@ import Data.Aeson.Parser.Internal (decodeWith, decodeStrictWith,
 import Data.ByteString as B
 import Data.ByteString.Lazy as L
 ")
-            (goto-char (point-min))
-            (purescript-sort-imports)
-            (string= (buffer-string)
+    (goto-char (point-min))
+    (purescript-sort-imports)
+    (should (string= (buffer-string)
                      "import Data.Aeson.Encode (encode)
 import Data.Aeson.Parser.Internal (decodeWith, decodeStrictWith,
                                    eitherDecodeWith, eitherDecodeStrictWith,

--- a/tests/purescript-sort-imports-tests.el
+++ b/tests/purescript-sort-imports-tests.el
@@ -45,23 +45,23 @@ import B
 import B
 ")))
   (should (with-temp-buffer
-            (insert "import qualified A
+            (insert "import A (A, B, C)
 import B
 ")
             (goto-char (point-min))
             (purescript-sort-imports)
             (string= (buffer-string)
-                     "import qualified A
+                     "import A (A, B, C)
 import B
 ")))
   (should (with-temp-buffer
-            (insert "import qualified \"mtl\" A
+            (insert "import A (mtl)
 import B
 ")
             (goto-char (point-min))
             (purescript-sort-imports)
             (string= (buffer-string)
-                     "import qualified \"mtl\" A
+                     "import A (mtl)
 import B
 "))))
 
@@ -116,8 +116,8 @@ import Data.Aeson.Types
 import Data.Aeson.Parser.Internal (decodeWith, decodeStrictWith,
                                    eitherDecodeWith, eitherDecodeStrictWith,
                                    jsonEOF, json, jsonEOF', json')
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as L
+import Data.ByteString as B
+import Data.ByteString.Lazy as L
 ")
             (goto-char (point-min))
             (purescript-sort-imports)
@@ -127,8 +127,8 @@ import Data.Aeson.Parser.Internal (decodeWith, decodeStrictWith,
                                    eitherDecodeWith, eitherDecodeStrictWith,
                                    jsonEOF, json, jsonEOF', json')
 import Data.Aeson.Types
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as L
+import Data.ByteString as B
+import Data.ByteString.Lazy as L
 "))))
 
 (provide 'purescript-sort-imports-tests)


### PR DESCRIPTION
This PR basically does two things: stops considering `qualified` as part of PureScript syntax, and removes extraneous autoload from the sorting function *(the sorting is only useful as part of purescript-mode, which should bring the function into the scope by virtue of `require`ing the module)*.

It may be desired to remove `qualified` from elsewhere as well, but there're a lot of things to improve, so let's do them one small step at a time 😊