### PR TITLE
ci: remove minor releases from the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,8 @@ jobs:
       matrix:
         emacs_version:
           - 25.1
-          - 25.2
-          - 25.3
           - 26.1
-          - 26.2
-          - 26.3
           - 27.1
-          - 27.2
           - 28.1
           - snapshot
     steps:


### PR DESCRIPTION
No point in testing minor Emacs releases, because they have no major features anyway, fixes only. E.g. given Emacs 25: 25.1, 25.2 and 25.3 are only different in amount of fixes. It isn't expected that something may break between these releases.

So there's not much point in running tests on all of them. This commit removes most minor Emacs versions and only leaves in the initial release for each Emacs major version.

It was brought up here before
https://github.com/purescript-emacs/purescript-mode/pull/33#issuecomment-2649211246 so far to no opposition.