### PR TITLE
Fix imports getting unsolicited indentation

### DIFF
--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -993,7 +993,7 @@ indent the current line. This has to be fixed elsewhere."
   "Return token starting at point."
   (cond ((looking-at
           (rx (group
-               (or "if" "then" "else" "let" "in" "ado" "mdo" "rec"
+               (or "if" "then" "else" "let" "in" "ado" "mdo" "rec" "import"
                    (seq (0+ (seq (1+ word) ".")) "do")
                    "proc" "case" "of" "where" "module" "data" "type" "newtype"
                    "class" "instance"))

--- a/tests/purescript-indentation-tests.el
+++ b/tests/purescript-indentation-tests.el
@@ -75,7 +75,6 @@ data Foo = Foo1 Bar |
            Foo3 Unit"))
 
 (ert-deftest imports-zero-indented ()
-  :expected-result :failed
   (purescript-test-indentation "
 module MyModule where
 


### PR DESCRIPTION
When pressing RET after an import, the line gets indented even though it shouldn't. Fix that.