### PR TITLE
Add missing `require 'autoloads` for `make all` to start working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ $(AUTOLOADS): $(ELFILES) purescript-mode.elc
 	$(BATCH) \
 		--eval '(setq make-backup-files nil)' \
 		--eval '(setq generated-autoload-file "$(CURDIR)/$@")' \
+		--eval "(require 'autoload)" \
 		-f batch-update-autoloads "."
 
 # HACK: embed version number into .elc file


### PR DESCRIPTION
Worth noting that it uses deprecated autoloads lib, but offhand I couldn't figure out how to replace it with `loaddefs-generate-batch`, and I don't think it's even worth putting time into because nobody's likely gonna use this anyway. Let's just fix the make rule because it's easy to.