### PR TITLE
Fix "unused arg" warning in `purescript-presentation-mode`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ ELFILES = \
 	purescript-mode.el \
 	purescript-move-nested.el \
 	purescript-navigate-imports.el \
+	purescript-presentation-mode.el \
 	purescript-simple-indent.el \
 	purescript-sort-imports.el \
 	purescript-str.el \

--- a/purescript-presentation-mode.el
+++ b/purescript-presentation-mode.el
@@ -35,7 +35,7 @@
 
 (define-key purescript-presentation-mode-map (kbd "q") 'quit-window)
 
-(defun purescript-present (name session code)
+(defun purescript-present (name _ code)
   "Present CODE in a popup buffer suffixed with NAME and set
 SESSION as the current purescript-session."
   (let* ((name (format "*PureScript Presentation%s*" name))


### PR DESCRIPTION
I'm not sure if the mode is even useful in Purescript because I'm not exactly clear what it does (keep in mind this code was part of haskell-mode before fork happened), but let's for now at least make sure it doesn't produce warning and is included in compilation.

Fixes warning:

    purescript-presentation-mode.el:38:33: Error: Unused lexical argument ‘session’