### PR TITLE
Strengthen "foreign import" highlight

### DIFF
--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -230,13 +230,6 @@ Returns keywords suitable for `font-lock-keywords'."
              (2 (symbol-value 'purescript-keyword-face) nil lax))
 
             (,reservedsym 1 (symbol-value 'purescript-operator-face))
-            ;; Special case for `foreign export'
-            ;; keywords in foreign export statements but are not otherwise reserved.
-            ("\\<\\(foreign\\)[ \t]+\\(export\\)[ \t]+\\(?:\\(ccall\\|stdcall\\|cplusplus\\|jvm\\|dotnet\\)[ \t]+\\)?"
-             (1 (symbol-value 'purescript-keyword-face) nil lax)
-             (2 (symbol-value 'purescript-keyword-face) nil lax)
-             (3 (symbol-value 'purescript-keyword-face) nil lax))
-
             ;; Toplevel Declarations.
             ;; Place them *before* generic id-and-op highlighting.
             (,topdecl-var  (1 (symbol-value 'purescript-definition-face)))

--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -223,13 +223,10 @@ Returns keywords suitable for `font-lock-keywords'."
              (4 (symbol-value 'purescript-keyword-face) nil lax))
 
             (,reservedsym 1 (symbol-value 'purescript-operator-face))
-            ;; Special case for `foreign import'
-            ;; keywords in foreign import statements but are not otherwise reserved.
-            ("\\<\\(foreign\\)[ \t]+\\(import\\)[ \t]+\\(?:\\(ccall\\|stdcall\\|cplusplus\\|jvm\\|dotnet\\)[ \t]+\\)?\\(?:\\(safe\\|unsafe\\|interruptible\\)[ \t]+\\)?"
+            ;; Case for `foreign import'
+            ("\\<\\(foreign\\)[ \t]+\\(import\\>\\)"
              (1 (symbol-value 'purescript-keyword-face) nil lax)
-             (2 (symbol-value 'purescript-keyword-face) nil lax)
-             (3 (symbol-value 'purescript-keyword-face) nil lax)
-             (4 (symbol-value 'purescript-keyword-face) nil lax))
+             (2 (symbol-value 'purescript-keyword-face) nil lax))
 
             (,reservedsym 1 (symbol-value 'purescript-operator-face))
             ;; Special case for `foreign export'

--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -224,7 +224,8 @@ Returns keywords suitable for `font-lock-keywords'."
 
             (,reservedsym 1 (symbol-value 'purescript-operator-face))
             ;; Case for `foreign import'
-            ("\\<\\(foreign\\)[ \t]+\\(import\\>\\)"
+            (,(rx line-start (0+ whitespace)
+                  (group "foreign") (1+ whitespace) (group "import") word-end)
              (1 (symbol-value 'purescript-keyword-face) nil lax)
              (2 (symbol-value 'purescript-keyword-face) nil lax))
 

--- a/tests/purescript-font-lock-tests.el
+++ b/tests/purescript-font-lock-tests.el
@@ -303,3 +303,49 @@ derive newtype instance foldableNonEmptyList :: Foldable NonEmptyList
      (449 450 font-lock-variable-name-face) (451 451 nil)
      (452 459 font-lock-type-face) (460 460 nil)
      (461 472 font-lock-type-face) (473 473 nil))))
+
+(ert-deftest foreign-imports ()
+  (purescript-test-ranges
+   "foreign import func2 :: Effect Int
+foreign import func3
+  :: Effect Int
+foreign import
+  func4 :: Effect Int
+  foreign import func5 -- invalid indentation, but allowed in other context
+"
+   '((1 7 font-lock-keyword-face)
+     (8 8 nil)
+     (9 14 font-lock-keyword-face)
+     (15 21 nil)
+     (22 23 font-lock-variable-name-face)
+     (24 24 nil)
+     (25 30 font-lock-type-face)
+     (31 31 nil)
+     (32 34 font-lock-type-face)
+     (35 35 nil)
+     (36 42 font-lock-keyword-face)
+     (43 43 nil)
+     (44 49 font-lock-keyword-face)
+     (50 58 nil)
+     (59 60 font-lock-variable-name-face)
+     (61 61 nil)
+     (62 67 font-lock-type-face)
+     (68 68 nil)
+     (69 71 font-lock-type-face)
+     (72 72 nil)
+     (73 79 font-lock-keyword-face)
+     (80 80 nil)
+     (81 86 font-lock-keyword-face)
+     (87 95 nil)
+     (96 97 font-lock-variable-name-face)
+     (98 98 nil)
+     (99 104 font-lock-type-face)
+     (105 105 nil)
+     (106 108 font-lock-type-face)
+     (109 111 nil)
+     (112 118 font-lock-keyword-face)
+     (119 119 nil)
+     (120 125 font-lock-keyword-face)
+     (126 132 nil)
+     (133 135 font-lock-comment-delimiter-face)
+     (136 185 font-lock-comment-face))))

--- a/tests/purescript-font-lock-tests.el
+++ b/tests/purescript-font-lock-tests.el
@@ -312,6 +312,8 @@ foreign import func3
 foreign import
   func4 :: Effect Int
   foreign import func5 -- invalid indentation, but allowed in other context
+invalid_dont_highlight foreign import func6
+foreign importinvalid
 "
    '((1 7 font-lock-keyword-face)
      (8 8 nil)
@@ -348,4 +350,8 @@ foreign import
      (120 125 font-lock-keyword-face)
      (126 132 nil)
      (133 135 font-lock-comment-delimiter-face)
-     (136 185 font-lock-comment-face))))
+     (136 185 font-lock-comment-face)
+     (186 207 font-lock-function-name-face)
+     (208 229 nil)
+     (230 236 font-lock-function-name-face)
+     (237 251 nil))))


### PR DESCRIPTION
This fixes a bug where `foreign import` wasn't getting highlighted if it's the only text on the line, adds a bunch of tests for this syntax, and gets rid of `foreign export`, which isn't a thing in PureScript, [as can be seen here](https://github.com/purescript/purescript/blob/fc3fa8897916de1a3973de976eaea1fba23b4df9/src/Language/PureScript/CST/Parser.y#L680-L681).
