### PR TITLE
purescript-font-lock.el: highlight docstrings unconditionally

### DIFF
--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -259,11 +259,6 @@ Returns keywords suitable for `font-lock-keywords'."
      ("^\\(\\\\\\)end{code}$" 1 "!"))
    purescript-basic-syntactic-keywords))
 
-(defcustom purescript-font-lock-docstrings (boundp 'font-lock-doc-face)
-  "If non-nil try to highlight docstring comments specially."
-  :type 'boolean
-  :group 'purescript)
-
 (defun purescript-syntactic-face-function (state)
   "`font-lock-syntactic-face-function' for PureScript."
   (cond
@@ -285,10 +280,9 @@ Returns keywords suitable for `font-lock-keywords'."
    ;; https://github.com/purescript/documentation/blob/master/language/Syntax.md
    ;; IOW, given a `-- | foo' line followed by `-- bar' line, the latter is a
    ;; plain comment.
-   ((and purescript-font-lock-docstrings
-         (save-excursion
-           (goto-char (nth 8 state))
-           (looking-at "\\(--\\|{-\\)[ \\t]*[|^]")))
+   ((save-excursion
+      (goto-char (nth 8 state))
+      (looking-at "\\(--\\|{-\\)[ \\t]*[|^]"))
     'font-lock-doc-face)
    (t 'font-lock-comment-face)))
 


### PR DESCRIPTION
The variable was introduced to avoid highlighting docstrings for Emacs versions where `font-lock-doc-face` didn't exist, that is prior to 21.

It's a variable from very old times and nowadays we support Emacs 25.1+ which has font-lock-doc-face. So remove the variable and the condition.

For the safe case I did search over Github, and the variable isn't mentioned anywhere except the literal copies of the font-lock.el file.
