### PR TITLE
Defvars cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ELFILES = \
 	purescript-utils.el \
 	purescript-decl-scan.el \
 	purescript-yas.el \
+	purescript-vars.el \
 	tests/purescript-sort-imports-tests.el \
 	tests/purescript-indentation-tests.el \
 	tests/purescript-font-lock-tests.el \

--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -306,13 +306,13 @@ Returns keywords suitable for `font-lock-keywords'."
 
 ;;;###autoload
 (defun purescript-font-lock-choose-keywords ()
-  (cl-case (bound-and-true-p purescript-literate)
+  (cl-case purescript-literate
     (bird purescript-font-lock-bird-literate-keywords)
     ((latex tex) purescript-font-lock-latex-literate-keywords)
     (t purescript-font-lock-keywords)))
 
 (defun purescript-font-lock-choose-syntactic-keywords ()
-  (cl-case (bound-and-true-p purescript-literate)
+  (cl-case purescript-literate
     (bird purescript-bird-syntactic-keywords)
     ((latex tex) purescript-latex-syntactic-keywords)
     (t purescript-basic-syntactic-keywords)))

--- a/purescript-font-lock.el
+++ b/purescript-font-lock.el
@@ -69,6 +69,7 @@
 
 (require 'font-lock)
 (require 'cl-lib)
+(require 'purescript-vars)
 
 (defcustom purescript-font-lock-prettify-symbols-alist
   `(("/\\" . ,(decode-char 'ucs #X2227))
@@ -262,8 +263,6 @@ Returns keywords suitable for `font-lock-keywords'."
   "If non-nil try to highlight docstring comments specially."
   :type 'boolean
   :group 'purescript)
-
-(defvar purescript-literate)
 
 (defun purescript-syntactic-face-function (state)
   "`font-lock-syntactic-face-function' for PureScript."

--- a/purescript-indent.el
+++ b/purescript-indent.el
@@ -1486,9 +1486,8 @@ One indentation cycle is used."
 
 ;;; purescript-indent-mode
 
-(defvar purescript-indent-mode nil
+(defvar-local purescript-indent-mode nil
   "Non-nil if the semi-intelligent PureScript indentation mode is in effect.")
-(make-variable-buffer-local 'purescript-indent-mode)
 
 (defvar purescript-indent-map
   (let ((map (make-sparse-keymap)))

--- a/purescript-indent.el
+++ b/purescript-indent.el
@@ -88,10 +88,9 @@
 
 ;;; Code:
 
+(require 'purescript-vars)
 (require 'purescript-string)
 (require 'cl-lib)
-
-(defvar purescript-literate)
 
 (defgroup purescript-indent nil
   "PureScript indentation."

--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -34,9 +34,8 @@
 
 (require 'syntax)
 (require 'cl-lib)
+(require 'simple)
 (require 'purescript-vars)
-
-(defvar delete-active-region)
 
 ;; Dynamically scoped variables.
 (defvar following-token)

--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -47,7 +47,7 @@
 (defvar parse-line-number)
 (defvar possible-indentations)
 (defvar indentation-point)
-(defvar purescript-indent-last-position)
+(defvar-local purescript-indent-last-position nil)
 
 (defgroup purescript-indentation nil
   "PureScript indentation."
@@ -133,9 +133,7 @@ autofill-mode."
     (set (make-local-variable 'indent-line-function)
          'purescript-indentation-indent-line)
     (set (make-local-variable 'normal-auto-fill-function)
-         'purescript-indentation-auto-fill-function)
-    (set (make-local-variable 'purescript-indent-last-position)
-         nil)))
+         'purescript-indentation-auto-fill-function)))
 
 ;;;###autoload
 (defun turn-on-purescript-indentation ()

--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -34,6 +34,7 @@
 
 (require 'syntax)
 (require 'cl-lib)
+(require 'purescript-vars)
 
 (defvar delete-active-region)
 
@@ -47,7 +48,6 @@
 (defvar parse-line-number)
 (defvar possible-indentations)
 (defvar indentation-point)
-(defvar purescript-literate)
 
 (defgroup purescript-indentation nil
   "PureScript indentation."

--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -126,14 +126,12 @@ set and deleted as if they were real tabs.  It supports
 autofill-mode."
   :lighter " Ind"
   :keymap purescript-indentation-mode-map
-  (kill-local-variable 'indent-line-function)
-  (kill-local-variable 'normal-auto-fill-function)
   (when purescript-indentation-mode
     (setq max-lisp-eval-depth (max max-lisp-eval-depth 600)) ;; set a higher limit for recursion
-    (set (make-local-variable 'indent-line-function)
-         'purescript-indentation-indent-line)
-    (set (make-local-variable 'normal-auto-fill-function)
-         'purescript-indentation-auto-fill-function)))
+    (setq-local indent-line-function
+                #'purescript-indentation-indent-line)
+    (setq-local normal-auto-fill-function
+                #'purescript-indentation-auto-fill-function)))
 
 ;;;###autoload
 (defun turn-on-purescript-indentation ()

--- a/purescript-indentation.el
+++ b/purescript-indentation.el
@@ -37,7 +37,7 @@
 (require 'simple)
 (require 'purescript-vars)
 
-;; Dynamically scoped variables.
+;; Dynamically scoped internal variables.
 (defvar following-token)
 (defvar current-token)
 (defvar left-indent)
@@ -47,6 +47,7 @@
 (defvar parse-line-number)
 (defvar possible-indentations)
 (defvar indentation-point)
+(defvar purescript-indent-last-position)
 
 (defgroup purescript-indentation nil
   "PureScript indentation."
@@ -116,9 +117,6 @@
     (define-key keymap [backspace] 'purescript-indentation-delete-backward-char)
     (define-key keymap [?\C-d] 'purescript-indentation-delete-char)
     keymap))
-
-;; Used internally
-(defvar purescript-indent-last-position)
 
 ;;;###autoload
 (define-minor-mode purescript-indentation-mode

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -34,6 +34,7 @@
 (require 'dabbrev)
 (require 'compile)
 (require 'outline)
+(require 'purescript-vars)
 (require 'purescript-align-imports)
 (require 'purescript-sort-imports)
 (require 'purescript-string)
@@ -101,16 +102,6 @@ sure all purescript customize definitions have been loaded."
           purescript-yas))
   (customize-browse 'purescript))
 
-;; Are we looking at a literate script?
-(defvar-local purescript-literate nil
-  "*If not nil, the current buffer contains a literate PureScript script.
-Possible values are: `bird' and `tex', for Bird-style and LaTeX-style
-literate scripts respectively.  Set by `purescript-mode' and
-`literate-purescript-mode'.  For an ambiguous literate buffer -- i.e. does
-not contain either \"\\begin{code}\" or \"\\end{code}\" on a line on
-its own, nor does it contain \">\" at the start of a line -- the value
-of `purescript-literate-default' is used.")
-(put 'purescript-literate 'safe-local-variable 'symbolp)
 ;; Default literate style for ambiguous literate buffers.
 (defcustom purescript-literate-default 'bird
   "Default value for `purescript-literate'.

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -279,8 +279,6 @@ details."
              turn-on-purescript-simple-indent
              turn-on-purescript-unicode-input-method))
 
-(defvar eldoc-print-current-symbol-info-function)
-
 ;; The main mode functions
 ;;;###autoload
 (define-derived-mode purescript-mode prog-mode "PureScript"

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -102,7 +102,7 @@ sure all purescript customize definitions have been loaded."
   (customize-browse 'purescript))
 
 ;; Are we looking at a literate script?
-(defvar purescript-literate nil
+(defvar-local purescript-literate nil
   "*If not nil, the current buffer contains a literate PureScript script.
 Possible values are: `bird' and `tex', for Bird-style and LaTeX-style
 literate scripts respectively.  Set by `purescript-mode' and
@@ -110,7 +110,6 @@ literate scripts respectively.  Set by `purescript-mode' and
 not contain either \"\\begin{code}\" or \"\\end{code}\" on a line on
 its own, nor does it contain \">\" at the start of a line -- the value
 of `purescript-literate-default' is used.")
-(make-variable-buffer-local 'purescript-literate)
 (put 'purescript-literate 'safe-local-variable 'symbolp)
 ;; Default literate style for ambiguous literate buffers.
 (defcustom purescript-literate-default 'bird

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -325,10 +325,7 @@ see documentation for that variable for more details."
   (setq-local beginning-of-defun-function 'purescript-beginning-of-defun)
   (setq prettify-symbols-alist purescript-font-lock-prettify-symbols-alist
         ;; make (ff-find-other-file) find .js FFI file, given .purs
-        ff-other-file-alist '((".purs\\'" (".js"))))
-  (when (bound-and-true-p purescript-font-lock-symbols)
-    (warn "`purescript-font-lock-symbols' is obsolete: please enable `prettify-symbols-mode' locally or globally instead."))
-  )
+        ff-other-file-alist '((".purs\\'" (".js")))))
 
 (defun purescript-fill-paragraph (justify)
   (save-excursion

--- a/purescript-vars.el
+++ b/purescript-vars.el
@@ -1,0 +1,33 @@
+;;; purescript-vars.el --- Variable definitions for PureScript Mode -*- lexical-binding: t -*-
+
+;; Author: 1997-1998 Graeme E Moss <gem@cs.york.ac.uk>
+;;         1997-1998 Tommy Thorn <thorn@irisa.fr>
+;;         2003      Dave Love <fx@gnu.org>
+;;         2025      Konstantin Kharlamov <Hi-Angel@yandex.ru>
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(defvar-local purescript-literate nil
+  "If not nil, the current buffer contains a literate PureScript script.
+Possible values are: `bird' and `tex', for Bird-style and LaTeX-style
+literate scripts respectively.  Set by `purescript-mode' and
+`literate-purescript-mode'.  For an ambiguous literate buffer -- i.e. does
+not contain either \"\\begin{code}\" or \"\\end{code}\" on a line on
+its own, nor does it contain \">\" at the start of a line -- the value
+of `purescript-literate-default' is used.")
+(put 'purescript-literate 'safe-local-variable 'symbolp)
+
+(provide 'purescript-vars)


### PR DESCRIPTION
This does defvar cleanup; most notably it moves `purescript-literate` to a shared location to make other files stop doing `(defvar purescript-literate)`, and it replaces some `defvar + make-local-variable` chains with just `defvar-local`.