### PR TITLE
Get rid of purescript-string module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ ELFILES = \
 	purescript-simple-indent.el \
 	purescript-sort-imports.el \
 	purescript-str.el \
-	purescript-string.el \
 	purescript-unicode-input-method.el \
 	purescript-utils.el \
 	purescript-decl-scan.el \

--- a/purescript-indent.el
+++ b/purescript-indent.el
@@ -91,6 +91,9 @@
 (require 'purescript-vars)
 (require 'purescript-string)
 (require 'cl-lib)
+(eval-when-compile
+  (when (< emacs-major-version 28)
+    (require 'subr-x)))
 
 (defgroup purescript-indent nil
   "PureScript indentation."
@@ -655,8 +658,8 @@ symbols in the sexp."
           (string-match "where[ \t]*" purescript-indent-current-line-first-ident))
          (diff-first                 ; not a function def with the same name
           (or (null valname-string)
-              (not (string= (purescript-trim valname-string)
-                            (purescript-trim purescript-indent-current-line-first-ident)))))
+              (not (string= (string-trim valname-string)
+                            (string-trim purescript-indent-current-line-first-ident)))))
 
          ;; (is-type-def
          ;;  (and rpurs-sign (eq (char-after rpurs-sign) ?\:)))

--- a/purescript-indent.el
+++ b/purescript-indent.el
@@ -89,7 +89,6 @@
 ;;; Code:
 
 (require 'purescript-vars)
-(require 'purescript-string)
 (require 'cl-lib)
 (eval-when-compile
   (when (< emacs-major-version 28)

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -439,7 +439,7 @@ Brings up the documentation for purescript-mode-hook."
       (message "%s"
                (concat (car lines)
                        (if (and (cdr lines) (stringp (cadr lines)))
-                           (format " [ %s .. ]" (purescript-string-take (purescript-trim (cadr lines)) 10))
+                           (format " [ %s .. ]" (purescript-string-take (string-trim (cadr lines)) 10))
                          ""))))))
 
 (defun purescript-current-line-string ()

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -432,6 +432,12 @@ Brings up the documentation for purescript-mode-hook."
     (goto-char (+ (line-beginning-position)
                   col))))
 
+(defun purescript-string-take (string n)
+  "Take n chars from string."
+  (substring string
+             0
+             (min (length string) n)))
+
 (defun purescript-mode-message-line (str)
   "Message only one line, multiple lines just disturbs the programmer."
   (let ((lines (split-string str "\n" t)))

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -37,7 +37,6 @@
 (require 'purescript-vars)
 (require 'purescript-align-imports)
 (require 'purescript-sort-imports)
-(require 'purescript-string)
 (require 'purescript-font-lock)
 (require 'cl-lib)
 (cl-eval-when 'compile (require 'find-file))

--- a/purescript-string.el
+++ b/purescript-string.el
@@ -1,13 +1,5 @@
 ;;; purescript-string.el --- string manipulation utilties -*- lexical-binding: t -*-
 ;;;###autoload
-(defun purescript-trim (string)
-  (replace-regexp-in-string
-   "^[ \t\n]+" ""
-   (replace-regexp-in-string
-    "[ \t\n]+$" ""
-    string)))
-
-;;;###autoload
 (defun purescript-string-take (string n)
   "Take n chars from string."
   (substring string

--- a/purescript-string.el
+++ b/purescript-string.el
@@ -1,9 +1,0 @@
-;;; purescript-string.el --- string manipulation utilties -*- lexical-binding: t -*-
-;;;###autoload
-(defun purescript-is-prefix-of (x y)
-  "Is x string a prefix of y string?"
-  (string= x (substring y 0 (min (length y) (length x)))))
-
-(defun purescript-string ())
-
-(provide 'purescript-string)

--- a/purescript-string.el
+++ b/purescript-string.el
@@ -1,12 +1,5 @@
 ;;; purescript-string.el --- string manipulation utilties -*- lexical-binding: t -*-
 ;;;###autoload
-(defun purescript-string-take (string n)
-  "Take n chars from string."
-  (substring string
-             0
-             (min (length string) n)))
-
-;;;###autoload
 (defun purescript-is-prefix-of (x y)
   "Is x string a prefix of y string?"
   (string= x (substring y 0 (min (length y) (length x)))))


### PR DESCRIPTION
This module provided 3 small functions, which are not really related to the mode, but for some reason have been "autoloaded". Replace `purescript-trim` with the usual `string-trim`, localize `purescript-string-take` to where it's used, and remove unused `purescript-is-prefix-of` altogether with `purescript-string.el`.