### PR TITLE
Improve indentation config msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,19 @@ and recommended installation method.
 Basic Configuration
 -------------------
 
-For setup instructions, please consult the new integrated purescript-mode
-[Info](https://www.gnu.org/software/texinfo/manual/info/info.html)
-manual which can be accessed after installation via
-`M-x info-display-manual [RET] purescript-mode`.
+PureScript mode provides multiple indentation engines, and leaves the choice up to the user. To have indentation an according indentation mode needs to be enabled. Otherwise, attempting to indent will print an error describing this.
+
+Minimal configuration may look something like:
+
+```lisp
+(use-package purescript-mode
+  :defer t
+  :config
+  (defun myhook-purescript-mode ()
+    (turn-on-purescript-indentation)
+    (add-hook 'before-save-hook #'purescript-sort-imports nil t))
+  (add-hook 'purescript-mode-hook #'myhook-purescript-mode))
+```
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -81,13 +81,3 @@ Minimal configuration may look something like:
     (add-hook 'before-save-hook #'purescript-sort-imports nil t))
   (add-hook 'purescript-mode-hook #'myhook-purescript-mode))
 ```
-
-Support
--------
-
-- [Github homepage](https://github.com/purescript-emacs/purescript-mode)
-
-Contributing
-------------
-
-Please make sure your pull requests are at least properly rebased and up to date.

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -407,7 +407,10 @@ is asked to show extra info for the items matching QUERY.."
 has been selected.
 
 Brings up the documentation for purescript-mode-hook."
-  (describe-variable 'purescript-mode-hook))
+  (error
+   "To use indentation you need to turn-on one of the indentation modes. Please see `purescript-mode-hook' documentation for examples.
+
+Currently `purescript-indentation' is the most maintained mode."))
 
 (defun purescript-mode-format-imports ()
   "Format the imports by aligning and sorting them."


### PR DESCRIPTION
Currently when a new user tries indenting, that basically invokes help for the
mode hook, which isn't useful and looks more like a bug than anything else.

Solve this by printing an explicit explanation that a user needs to enable an
indentation mode.

While at it, also remove "Support" and "Contributing" sections from the README, because they contain no useful information. The former is just a link to here *(which is pointless, because if a user reads it they already here)*, and the latter just has no useful info.
